### PR TITLE
throw an exception when connection fails

### DIFF
--- a/pdooci.php
+++ b/pdooci.php
@@ -61,6 +61,10 @@ class PDO
                 $this->_con = \oci_connect($username, $password, $data, $charset);
                 $this->setError();
             }
+            if (!$this->_con) {
+                $error = oci_error();
+                throw new \Exception($error['code'].': '.$error['message']);
+            }
         } catch (\Exception $exception) {
             throw new \PDOException($exception->getMessage());
         } 


### PR DESCRIPTION
This makes the constructor behave more like it's described in [the manual](http://www.php.net/manual/en/pdo.construct.php).
