### PR TITLE
Fix DSN and save LOBs through bindValue()

### DIFF
--- a/src/PDO.php
+++ b/src/PDO.php
@@ -53,7 +53,7 @@ class PDO extends \PDO
         $charset = null;
         $data    = preg_replace('/^oci:/', '', $data);
         $tokens  = preg_split('/;/', $data);
-        $data    = $tokens[0];
+        $data    = str_replace(array('dbname=//', 'dbname='), '', $tokens[0]);
         $charset = $this->_getCharset($tokens);
 
         try {


### PR DESCRIPTION
Valid DSN contains 'dbname=' or 'dbname=//':
[documentation](http://php.net/manual/en/ref.pdo-oci.connection.php)

LOBs save only in bindValue(), because in my experience bindParam() in native PDO hang on server.