### PR TITLE
PDO::ATTR_CASE support

### DIFF
--- a/src/PDO.php
+++ b/src/PDO.php
@@ -31,6 +31,7 @@ class PDO extends \PDO
     private $_autocommit = true;
     private $_last_error = null;
     private $_charset    = null;
+    private $_case       = \PDO::CASE_NATURAL;
 
     /**
      * Class constructor
@@ -185,6 +186,9 @@ class PDO extends \PDO
         case \PDO::ATTR_AUTOCOMMIT:
             $this->_autocommit = (is_bool($value) && $value) || in_array(strtolower($value), array("on", "true"));
             return;
+        case \PDO::ATTR_CASE:
+            $this->_case = $value;
+            return;
         }
     }
 
@@ -203,6 +207,8 @@ class PDO extends \PDO
             return $this->_autocommit;
         case \PDO::ATTR_DRIVER_NAME:
             return 'oci';
+        case \PDO::ATTR_CASE:
+            return $this->_case;
         }
         return null;
     }

--- a/test/connectionTest.php
+++ b/test/connectionTest.php
@@ -199,5 +199,30 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
         $id = self::$con->lastInsertId("people_sequence");
         $this->assertTrue(is_numeric($id));
     }
+
+    public function testCaseDefaultValue()
+    {
+        $case = self::$con->getAttribute(\PDO::ATTR_CASE);
+        $this->assertEquals(\PDO::CASE_NATURAL, $case);
+    }
+
+    /**
+     * Test setting case
+     * @param int $case
+     * @dataProvider caseProvider
+     */
+    public function testSettingCase($case)
+    {
+        self::$con->setAttribute(\PDO::ATTR_CASE, $case);
+        $this->assertEquals($case, self::$con->getAttribute(\PDO::ATTR_CASE));
+    }
+
+    public function caseProvider()
+    {
+        return array(
+            array(\PDO::CASE_LOWER),
+            array(\PDO::CASE_UPPER),
+        );
+    }
 }
 ?>

--- a/test/statementTest.php
+++ b/test/statementTest.php
@@ -166,6 +166,34 @@ class StatementTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider fetchAssocWithCaseProvider
+     * @param int $case
+     * @param string $name
+     * @param string $email
+     */
+    public function testFetchAssocWithCase($case, $name, $email)
+    {
+        $this->_insertValueWithExec();
+        self::$con->setAttribute(\PDO::ATTR_CASE, $case);
+        $stmt = self::$con->query("select * from people");
+        $data = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $stmt->closeCursor();
+        $this->assertTrue($this->_checkKeys(array($name,$email), array_keys($data)));
+        $this->assertEquals(2, sizeof($data));
+        $this->assertEquals("eustaquio", $data[$name]);
+        $this->assertEquals("eustaquiorangel@gmail.com", $data[$email]);
+    }
+
+    public function fetchAssocWithCaseProvider()
+    {
+        return array(
+            array(\PDO::CASE_LOWER, 'name', 'email'),
+            array(\PDO::CASE_UPPER, 'NAME', 'EMAIL'),
+            array(\PDO::CASE_NATURAL, 'NAME', 'EMAIL'),
+        );
+    }
+
+    /**
      * Test a fetch with PDO::FETCH_NUM
      *
      * @return null


### PR DESCRIPTION
This adds the ability to set PDO::ATTR_CASE attribute, which can be used to set which case result keys come back in. The default is PDO::CASE_NATURAL (ie, whatever
the database returns) which is a no-op. PDO::CASE_UPPER and PDO::CASE_LOWER will convert keys to upper and lower respectively.
I've only implemented case-fixing for fetch() with PDO::FETCH_ASSOC for now.
Includes unit tests.