### PR TITLE
Fix PHP notice on Statement.php

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -287,7 +287,7 @@ class Statement extends \PDOStatement implements \IteratorAggregate
             case \PDO::FETCH_NUM:
                 \oci_fetch_all($this->_stmt, $rst, 0, -1, \OCI_FETCHSTATEMENT_BY_ROW + \OCI_NUM);
                 break;
-                
+
             case \PDO::FETCH_BOTH:
                 \oci_fetch_all($this->_stmt, $rst, 0, -1, \OCI_FETCHSTATEMENT_BY_ROW + \OCI_NUM + \OCI_ASSOC);
                 break;
@@ -428,7 +428,7 @@ class Statement extends \PDOStatement implements \IteratorAggregate
     {
         return $this->_statement;
     }
-    
+
     /**
      * Return the iterator
      *
@@ -641,7 +641,7 @@ class Statement extends \PDOStatement implements \IteratorAggregate
         }
 
         return array_map(
-            function ($item) {
+            function ($item) use ($case) {
                 if (is_array($item)) {
                     $item = array_change_key_case($item, $case);
                 }


### PR DESCRIPTION
When using `\PDO::CASE_LOWER` to fetch results, the `$case` variable was out of scope, so a notice was being generated.