### PR TITLE
fetchColumn return false if no rows were found

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -358,7 +358,7 @@ class Statement extends \PDOStatement implements \IteratorAggregate
     public function fetchColumn($colnum=0)
     {
         $rst = $this->fetch(\PDO::FETCH_NUM);
-        return $rst[$colnum];
+        return $rst === false ? false : $rst[$colnum];
     }
 
     /**


### PR DESCRIPTION
Prevents `Trying to access array offset on value of type bool`

https://www.php.net/manual/en/pdostatement.fetchcolumn.php