### PR TITLE
:bug: Reset autocommit to true on commit and rollback

### DIFF
--- a/src/PDO.php
+++ b/src/PDO.php
@@ -234,6 +234,7 @@ class PDO extends \PDO
     public function commit()
     {
         \oci_commit($this->_con);
+        $this->setAttribute(\PDO::ATTR_AUTOCOMMIT, true);
         $this->setError();
     }
 
@@ -245,6 +246,7 @@ class PDO extends \PDO
     public function rollBack()
     {
         \oci_rollback($this->_con);
+        $this->setAttribute(\PDO::ATTR_AUTOCOMMIT, true);
         $this->setError();
     }
 


### PR DESCRIPTION
After starting a transaction the _autocommit variable was not set back to true after commit or rollback. What do you think about this fix? 